### PR TITLE
Setup verifier during init

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ const client = new Client({
   clientId: "YOUR_CLIENT_ID",
   redirectUri: REDIRECT_URI,
   scopes: ["transactions"],
-  state
+  state,
+  verifier
 });
 
 // redirect not authenticated user to Kontist form
 app.get("/auth", (req, res) => {
-  const uri = await client.getAuthUri({ verifier });
+  const uri = await client.getAuthUri();
   res.redirect(uri);
 });
 
@@ -46,7 +47,7 @@ app.get(CALLBACK_PATH, (req, res) => {
   const callbackUrl = req.originalUrl;
 
   try {
-    const token = await client.getToken(callbackUrl, { verifier });
+    const token = await client.getToken(callbackUrl);
     /* got access token, login successful */
   } catch (e) {
     /* handle error */
@@ -80,29 +81,28 @@ const result = await client.rawQuery(query);
     <script>
         // persist a random value
         sessionStorage.setItem("state", sessionStorage.getItem("state") || (Math.random() + "").substring(2));
+        sessionStorage.setItem("verifier", sessionStorage.getItem("verifier") || (Math.random() + "").substring(2));
 
         // initialize Kontist client
         let client = new Kontist.Client({
             clientId: "<your client id>",
             redirectUri: "<your base url>",
             scopes: ["transactions"],
-            state: sessionStorage.getItem("state")
+            state: sessionStorage.getItem("state"),
+            verifier: sessionStorage.getItem("verifier")
         });
 
         let params = (new URL(document.location)).searchParams;
         let code = params.get("code");
         if (!code) {
             // page not called with "code" query parameter, let's redirect the user to the login
-            let verifier = (Math.random() + "").substring(2);
-            sessionStorage.setItem("verifier", verifier);
-            client.getAuthUri({ verifier: verifier }).then(function(url) {
+            client.getAuthUri().then(function(url) {
                 window.location = url;
             });
         } else {
 
             // we have a code, the client now can fetch a token
-            let verifier = sessionStorage.getItem("verifier");
-            client.getToken(document.location.href, { verifier: verifier })
+            client.getToken(document.location.href)
               .then(function() {
 
                 // do a simple graphql query and output the account id

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -13,10 +13,12 @@ export class Client {
   private oauth2Client: ClientOAuth2;
   private graphQLClient: GraphQLClient;
   private token?: ClientOAuth2.Token;
+  private verifier?: string;
 
   constructor(opts: ClientOpts) {
     const baseUrl = opts.baseUrl || KONTIST_API_BASE_URL;
-    const { clientId, redirectUri, scopes, oauthClient } = opts;
+    const { clientId, redirectUri, scopes, oauthClient, state, verifier } = opts;
+    this.verifier = verifier;
 
     this.oauth2Client =
       oauthClient ||
@@ -26,7 +28,7 @@ export class Client {
         clientId,
         redirectUri,
         scopes,
-        state: opts.state
+        state
       });
 
     this.graphQLClient = new GraphQLClient(`${baseUrl}/api/graphql`);
@@ -40,10 +42,10 @@ export class Client {
       [key: string]: string | string[];
     } = {};
 
-    if (opts.verifier) {
+    if (this.verifier) {
       // Implemented according to https://tools.ietf.org/html/rfc7636#appendix-A
       const challenge =
-        (btoa(String.fromCharCode.apply(null, sha256.array(opts.verifier))) || "")
+        (btoa(String.fromCharCode.apply(null, sha256.array(this.verifier))) || "")
           .split("=")[0]
           .replace("+", "-")
           .replace("/", "_")
@@ -68,9 +70,9 @@ export class Client {
       };
     } = {};
 
-    if (opts.verifier) {
+    if (this.verifier) {
       options.body = {
-        code_verifier: opts.verifier
+        code_verifier: this.verifier
       };
     }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -7,6 +7,7 @@ export type ClientOpts = {
   redirectUri: string;
   scopes: string[];
   state: string;
+  verifier?: string;
 };
 
 export type GetAuthUriOpts = {

--- a/tests/Client.spec.ts
+++ b/tests/Client.spec.ts
@@ -21,13 +21,15 @@ describe("OAuth2 client tests", () => {
 
   describe("client with mandatory parameters", () => {
     let client: Client;
+    const verifier = "Huag6ykQU7SaEYKtmNUeM8txt4HzEIfG";
 
     beforeEach(() => {
       client = new Client({
         clientId,
         redirectUri,
         scopes,
-        state: "25843739712322056"
+        state: "25843739712322056",
+        verifier
       });
     });
 
@@ -36,25 +38,29 @@ describe("OAuth2 client tests", () => {
         clientId,
         redirectUri,
         scopes,
-        state: "25843739712322056"
+        state: "25843739712322056",
+        verifier
       });
       expect(client).to.exist;
     });
 
     describe("client.getAuthUri()", () => {
       it("should return proper redirect url", async () => {
+        client = new Client({
+          clientId,
+          redirectUri,
+          scopes,
+          state: "25843739712322056"
+        });
         const url = await client.getAuthUri();
         const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056`;
         expect(url).to.equal(expectedUrl);
       });
 
       it("should return proper redirect url when verifier is provided", async () => {
-        const codeVerifier = "Huag6ykQU7SaEYKtmNUeM8txt4HzEIfG";
         const codeChallenge = "xc3uY4-XMuobNWXzzfEqbYx3rUYBH69_zu4EFQIJH8w";
         const codeChallengeMethod = "S256";
-        const url = await client.getAuthUri({
-          verifier: codeVerifier
-        });
+        const url = await client.getAuthUri();
         const expectedUrl = `${Constants.KONTIST_API_BASE_URL}/api/oauth/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback&scope=transactions&response_type=code&state=25843739712322056&code_challenge=${codeChallenge}&code_challenge_method=${codeChallengeMethod}`;
         expect(url).to.equal(expectedUrl);
       });
@@ -83,12 +89,11 @@ describe("OAuth2 client tests", () => {
           oauthClient,
           redirectUri,
           scopes,
-          state: "25843739712322056"
-        });
-
-        tokenData = await clientMock.getToken(callbackUrl, {
+          state: "25843739712322056",
           verifier: oauth2PKCECodeVerifier
         });
+
+        tokenData = await clientMock.getToken(callbackUrl);
       });
 
       it("should call oauthClient.code.getToken() with proper arguments", () => {


### PR DESCRIPTION
Setup `verifier` (optional) during the initialization and save it in the `Client` object. This simplifies the calls of `getAuthUri` and `getToken` a bit. Let me know what you think.