### PR TITLE
Reduce lib bundle size

### DIFF
--- a/lib/graphql/transaction.ts
+++ b/lib/graphql/transaction.ts
@@ -1,4 +1,4 @@
-import { get } from "lodash";
+import get = require("lodash/get");
 import {
   Query,
   TransactionsConnectionEdge,


### PR DESCRIPTION
https://github.com/lodash/lodash/issues/3192#issuecomment-343737364

Reduces bundle size:
Before:
Hash: b5fc49be717152b9f58d
Version: webpack 4.41.2
Time: 356ms
Built at: 10/31/2019 2:21:15 PM
    Asset     Size  Chunks             Chunk Names
bundle.js  **134 KiB**       0  [emitted]  main

After:
Hash: 00f5a55d7852d53dbdc8
Version: webpack 4.41.2
Time: 284ms
Built at: 10/31/2019 2:21:40 PM
    Asset      Size  Chunks             Chunk Names
bundle.js  **71.6 KiB**       0  [emitted]  main

Unfortunately TypeScript was complaining about when wanted to import it from "lodash/get" with standard way.